### PR TITLE
Make emit work in jest

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,15 @@
 declare function warning (): Warning
 
-export declare class FastifyWarning extends Error {
-  code: string
+export declare class WarnOpts {
+  code: string;
+  name: string;
+  message: string;
 }
 
+export type BuildWarnOptsFn = (a?: any, b?: any, c?: any) => WarnOpts
+
 interface Warning {
-  create(name: string, code: string, message: string): FastifyWarning,
+  create(name: string, code: string, message: string): BuildWarnOptsFn,
   emit(cod: string, a?: any, b?: any, c?: any): void,
   emitted: Map<string, boolean>
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,11 +1,14 @@
 import { expectType } from 'tsd'
-import Warinig, { FastifyWarning } from './'
+import Warinig, { BuildWarnOptsFn, WarnOpts } from './'
 
 const warning = Warinig()
-const warn = warning.create('FastifyWarning', 'CODE', 'message')
-expectType<FastifyWarning>(warn)
-expectType<string>(warn.code)
-expectType<string>(warn.message)
+const buildWarnOpts = warning.create('FastifyWarning', 'CODE', 'message')
+expectType<BuildWarnOptsFn>(buildWarnOpts)
+const opts = buildWarnOpts()
+expectType<WarnOpts>(opts)
+expectType<string>(opts.code)
+expectType<string>(opts.message)
+expectType<string>(opts.name)
 
 expectType<void>(warning.emit('CODE'))
 expectType<Map<string, boolean>>(warning.emitted)

--- a/jest.test.js
+++ b/jest.test.js
@@ -1,0 +1,20 @@
+/* global test, expect */
+'use strict'
+
+const build = require('./')
+
+test('works with jest', done => {
+  const { create, emit, emitted } = build()
+
+  create('FastifyDeprecation', 'CODE', 'Hello %s')
+  emit('CODE', 'world')
+
+  // we cannot actually listen to process warning event
+  // because jest messes with it (that's the point of this test)
+  // we can only test it was emitted indirectly
+  // and test no exception is raised
+  setImmediate(() => {
+    expect(emitted.get('CODE')).toBeTruthy()
+    done()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "standard && ava -v && tsd"
+    "test": "standard && ava -v test.js && jest jest.test.js && tsd"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/fastify/fastify-warning#readme",
   "devDependencies": {
     "ava": "^3.10.1",
+    "jest": "^26.1.0",
     "standard": "^14.3.4",
     "tsd": "^0.13.1"
   }

--- a/test.js
+++ b/test.js
@@ -7,42 +7,38 @@ process.removeAllListeners('warning')
 
 test('Create warning with zero parameter', t => {
   const { create } = build()
-  const NewWarn = create('FastifyWarning', 'CODE', 'Not available')
-  const err = new NewWarn()
-  t.true(err instanceof Error)
-  t.is(err.name, 'FastifyWarning')
-  t.is(err.message, 'Not available')
-  t.is(err.code, 'CODE')
+  const buildWarnOpts = create('FastifyWarning', 'CODE', 'Not available')
+  const opts = buildWarnOpts()
+  t.is(opts.name, 'FastifyWarning')
+  t.is(opts.message, 'Not available')
+  t.is(opts.code, 'CODE')
 })
 
 test('Create error with 1 parameter', t => {
   const { create } = build()
-  const NewWarn = create('FastifyWarning', 'CODE', 'hey %s')
-  const err = new NewWarn('alice')
-  t.true(err instanceof Error)
-  t.is(err.name, 'FastifyWarning')
-  t.is(err.message, 'hey alice')
-  t.is(err.code, 'CODE')
+  const buildWarningOpts = create('FastifyWarning', 'CODE', 'hey %s')
+  const opts = buildWarningOpts('alice')
+  t.is(opts.name, 'FastifyWarning')
+  t.is(opts.message, 'hey alice')
+  t.is(opts.code, 'CODE')
 })
 
 test('Create error with 2 parameters', t => {
   const { create } = build()
-  const NewWarn = create('FastifyWarning', 'CODE', 'hey %s, I like your %s')
-  const err = new NewWarn('alice', 'attitude')
-  t.true(err instanceof Error)
-  t.is(err.name, 'FastifyWarning')
-  t.is(err.message, 'hey alice, I like your attitude')
-  t.is(err.code, 'CODE')
+  const buildWarnOpts = create('FastifyWarning', 'CODE', 'hey %s, I like your %s')
+  const opts = buildWarnOpts('alice', 'attitude')
+  t.is(opts.name, 'FastifyWarning')
+  t.is(opts.message, 'hey alice, I like your attitude')
+  t.is(opts.code, 'CODE')
 })
 
 test('Create error with 3 parameters', t => {
   const { create } = build()
-  const NewWarn = create('FastifyWarning', 'CODE', 'hey %s, I like your %s %s')
-  const err = new NewWarn('alice', 'attitude', 'see you')
-  t.true(err instanceof Error)
-  t.is(err.name, 'FastifyWarning')
-  t.is(err.message, 'hey alice, I like your attitude see you')
-  t.is(err.code, 'CODE')
+  const buildWarnOpts = create('FastifyWarning', 'CODE', 'hey %s, I like your %s %s')
+  const opts = buildWarnOpts('alice', 'attitude', 'see you')
+  t.is(opts.name, 'FastifyWarning')
+  t.is(opts.message, 'hey alice, I like your attitude see you')
+  t.is(opts.code, 'CODE')
 })
 
 test('Should throw when error code has no fastify name', t => {
@@ -70,23 +66,6 @@ test('Should throw when error has no message', t => {
   } catch (err) {
     t.is(err.message, 'Fastify warning message must not be empty')
   }
-})
-
-test('FastifyWarning.toString returns code', t => {
-  const { create } = build()
-  const NewWarn = create('FastifyWarning', 'CODE', 'foo')
-  const err = new NewWarn()
-  t.is(err.toString(), 'FastifyWarning [CODE]: foo')
-})
-
-test('Create the warning without the new keyword', t => {
-  const { create } = build()
-  const NewWarn = create('FastifyWarning', 'CODE', 'Not available')
-  const err = NewWarn()
-  t.true(err instanceof Error)
-  t.is(err.name, 'FastifyWarning')
-  t.is(err.message, 'Not available')
-  t.is(err.code, 'CODE')
 })
 
 test.serial.cb('emit should emit a given code only once', t => {


### PR DESCRIPTION
This should fix https://github.com/fastify/fastify-warning/issues/2, which is also similar to other issues reported to fastify itself (i.e. see https://github.com/fastify/fastify/issues/2438)

The underlying cause here is jest fiddling with sandboxing, context and globals. The result is that the `Error` global object available to fastify-warning is not the same object in the main node process and thus `FastifyWarning instanceOf Error` that is run in the implementation of `process.emitWarning` (see https://github.com/nodejs/node/blob/v10.22.0/lib/internal/process/warning.js#L146) fails.

The issues caused by jest sandboxing model have been known for a while now (see https://github.com/facebook/jest/issues/2549 and https://github.com/facebook/jest/issues/8246) and looks like they won't be solved soon.

This PR works around it by not emitting an error, but rather calling `emitWarning` with string params instead (documented here: https://nodejs.org/dist/latest-v12.x/docs/api/process.html#process_process_emitwarning_warning_type_code_ctor)

The downside of this approach is that `warning.create` won't be returning a constructor for an object that inherits from `Error`, but that apparently was never used in fastify.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] ~documentation is changed or added~
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
