### PR TITLE
Add note about codes needing to be uppercase to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ warning.create(name, code, message)
 ```
 
 - `name` (`string`, required) - The error name, you can access it later with `error.name`. For consistency, we recommend to prefix plugin error names with `FastifWarning{YourPluginName}`
-- `code` (`string`, required) - The warning code, you can access it later with `error.code`. For consistency, we recommend to prefix plugin error codes with `FST_{YourPluginName}_`
+- `code` (`string`, required) - The warning code, you can access it later with `error.code`. For consistency, we recommend to prefix plugin error codes with `FST_{YourPluginName}_`. NOTE: codes should be all uppercase.
 - `message` (`string`, required) - The warning message. You can also use interpolated strings for formatting the message.
 
 The utility also contains an `emit` function that you can use for emitting the warnings you have previously created by passing their respective code. A warning is guaranteed to be emitted only once.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

While working on https://github.com/fastify/light-my-request/pull/99, I was confused when my code wasn't found while calling `warning.emit()`.  It turned out that I had used lowercase letters, and the code has to be all uppercase.

I've added a note to the docs so that others don't trip over this.
